### PR TITLE
BUGFIX - Berserk Gene's confusion lasts for 256 turns or the previous Pokémon's confusion count

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -413,6 +413,16 @@ HandleBerserkGene:
 	call GetBattleVarAddr
 	push af
 	set SUBSTATUS_CONFUSED, [hl]
+	ldh a, [hBattleTurn]
+	and a
+	ld hl, wPlayerConfuseCount
+	jr z, .set_confuse_count
+	ld hl, wEnemyConfuseCount
+.set_confuse_count
+	call BattleRandom
+	and %11
+	add 2
+	ld [hl], a
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVarAddr
 	push hl


### PR DESCRIPTION
This makes the Berserk Gene use the regular confusion duration (2–5 turns).