### PR TITLE
BUGFIX - Present damage is incorrect in link battles

### DIFF
--- a/engine/battle/move_effects/present.asm
+++ b/engine/battle/move_effects/present.asm
@@ -1,21 +1,13 @@
 BattleCommand_Present:
 ; present
 
-	ld a, [wLinkMode]
-	cp LINK_COLOSSEUM
-	jr z, .colosseum_skippush
 	push bc
 	push de
-.colosseum_skippush
 
 	call BattleCommand_Stab
 
-	ld a, [wLinkMode]
-	cp LINK_COLOSSEUM
-	jr z, .colosseum_skippop
 	pop de
 	pop bc
-.colosseum_skippop
 
 	ld a, [wTypeMatchup]
 	and a


### PR DESCRIPTION
This bug existed for all battles in Gold and Silver, and was only fixed for single-player battles in Crystal to preserve link compatibility.