### PR TITLE
Moon Ball does not boost catch rate

### DIFF
--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -914,16 +914,11 @@ MoonBallMultiplier:
 	ret nz
 
 	inc hl
-	inc hl
-	inc hl
 
-; Moon Stone's constant from Pokémon Red is used.
-; No Pokémon evolve with Burn Heal,
-; so Moon Balls always have a catch rate of 1×.
 	push bc
 	ld a, BANK("Evolutions and Attacks")
 	call GetFarByte
-	cp MOON_STONE_RED ; BURN_HEAL
+	cp MOON_STONE
 	pop bc
 	ret nz
 


### PR DESCRIPTION
The Moon Ball checks the wrong memory address for the wrong item ID, so no Pokémon can receive the boost.